### PR TITLE
Fix bz init bugs: stdio, etc...

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -96,7 +96,7 @@ const makeFeatureJSON = (projectName, buildSettings) => `\
       "description": "test",
       "globalReadAccess": false,
       "globalWriteAccess": false,
-      "name": "some_collection",
+      "name": "sample_collection",
       "userWriteAccess": true
     }
   ],


### PR DESCRIPTION
- Just inherit standard out/error/in rather than copying data.  This fixes a hang during `react-native link`
- Symlink of bazaar.json does not work inside the shell script invoked within the spawned process. Moved to a spawned process at the end, along with the `bz publish schema` and `bz install sample-event-id` that must happen afterward.